### PR TITLE
Add preliminary fix for URL space tokens.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ buildNumber.properties
 /.classpath
 /.project
 /.settings/
+*.iml
+.idea

--- a/src/main/java/com/ociweb/gl/api/GreenRuntime.java
+++ b/src/main/java/com/ociweb/gl/api/GreenRuntime.java
@@ -681,6 +681,11 @@ public class GreenRuntime {
     
 
 	public void addFileServer(String path, int ... routes) {
+
+        // Strip URL space tokens from incoming path strings to avoid issues.
+        // TODO: This should be made garbage free.
+        // TODO: Is this expected behavior?
+        path = path.replaceAll("\\Q%20\\E", " ");
 				
 		//due to internal implementation we must keep the same number of outputs as inputs.
 		int r = routes.length;


### PR DESCRIPTION
The current GL file server behavior does not react well to being given paths that contain URL spaces ("%20"). This PR proposes a simple fix to automatically convert these tokens to spaces, provided this is expected behavior.