### PR TITLE
update pom to 1.8 and add client-server json encode/decodxe test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
                    <configuration>
                      
 		          	<fork>true</fork>
-		            <source>1.7</source>
-		            <target>1.7</target>
+		            <source>1.8</source>
+		            <target>1.8</target>
 		            <testSource>1.8</testSource>
 		            <testTarget>1.8</testTarget>
                

--- a/src/test/java/com/ociweb/gl/json/JSONAppTest.java
+++ b/src/test/java/com/ociweb/gl/json/JSONAppTest.java
@@ -1,0 +1,13 @@
+package com.ociweb.gl.json;
+
+import com.ociweb.gl.api.GreenRuntime;
+import org.junit.Test;
+
+public class JSONAppTest {
+    @Test
+    public void testApp() {
+        GreenRuntime.run(new JSONServerApp());
+        GreenRuntime.testUntilShutdownRequested(new JSONClient(), 2000);
+        System.out.println("Test shutdown");
+    }
+}

--- a/src/test/java/com/ociweb/gl/json/JSONClient.java
+++ b/src/test/java/com/ociweb/gl/json/JSONClient.java
@@ -1,0 +1,20 @@
+package com.ociweb.gl.json;
+
+import com.ociweb.gl.api.Builder;
+import com.ociweb.gl.api.GreenApp;
+import com.ociweb.gl.api.GreenRuntime;
+import com.ociweb.gl.api.HTTPSession;
+
+public class JSONClient implements GreenApp {
+    @Override
+    public void declareConfiguration(Builder builder) {
+        builder.useInsecureNetClient();
+    }
+    @Override
+    public void declareBehavior(GreenRuntime runtime) {
+        // Create the session
+        HTTPSession session = new HTTPSession("127.0.0.1",8088,0);
+        // Inject business logic
+        runtime.registerListener(new JSONClientBehavior(runtime, session)).includeHTTPSession(session);
+    }
+}

--- a/src/test/java/com/ociweb/gl/json/JSONClientBehavior.java
+++ b/src/test/java/com/ociweb/gl/json/JSONClientBehavior.java
@@ -1,0 +1,45 @@
+package com.ociweb.gl.json;
+
+import com.ociweb.gl.api.*;
+import com.ociweb.pronghorn.pipe.ChannelReader;
+import com.ociweb.pronghorn.pipe.ChannelWriter;
+import com.ociweb.pronghorn.util.parse.JSONReader;
+
+public class JSONClientBehavior implements HTTPResponseListener, StartupListener {
+    private final GreenRuntime runtime;
+    private final GreenCommandChannel command;
+    private final HTTPSession session;
+    private final JSONReader jsonReader = JSONObject.createReader();
+    private final JSONObject restResponse = new JSONObject();
+
+    JSONClientBehavior(GreenRuntime runtime, HTTPSession session) {
+        this.runtime = runtime;
+        this.command = runtime.newCommandChannel();
+        this.command.ensureHTTPClientRequesting();
+        this.session = session;
+    }
+
+    @Override
+    public void startup() {
+        command.httpPost(session, "/atp/location", new Writable() {
+            @Override
+            public void write(ChannelWriter writer) {
+                writer.write("{}".getBytes());
+            }
+        });
+    }
+
+    @Override
+    public boolean responseHTTP(HTTPResponseReader httpResponseReader) {
+        System.out.println("Client received response.");
+        // This crashes...
+        httpResponseReader.openPayloadData(new Payloadable() {
+            @Override
+            public void read(ChannelReader reader) {
+                restResponse.readFromJSON(jsonReader, reader);
+            }
+        });
+        runtime.shutdownRuntime();
+        return true;
+    }
+}

--- a/src/test/java/com/ociweb/gl/json/JSONObject.java
+++ b/src/test/java/com/ociweb/gl/json/JSONObject.java
@@ -1,0 +1,90 @@
+package com.ociweb.gl.json;
+
+import com.ociweb.json.JSONExtractor;
+import com.ociweb.json.JSONExtractorCompleted;
+import com.ociweb.json.JSONType;
+import com.ociweb.json.appendable.AppendableByteWriter;
+import com.ociweb.json.encode.JSONRenderer;
+import com.ociweb.pronghorn.pipe.ChannelReader;
+import com.ociweb.pronghorn.util.parse.JSONReader;
+
+public class JSONObject {
+    private int status = 0;
+    private final StringBuilder message = new StringBuilder();
+    private final StringBuilder body = new StringBuilder();
+
+    private static final JSONRenderer<JSONObject> jsonRenderer = new JSONRenderer<JSONObject>()
+            .beginObject()
+            .integer("status", o->o.status)
+            .string("message", o->o.message)
+            .string("body", o->o.body)
+            .endObject();
+
+    public static final JSONExtractorCompleted jsonExtractor = new JSONExtractor()
+            .newPath(JSONType.TypeInteger).key("status").completePath("status")
+            .newPath(JSONType.TypeString).key("message").completePath("message")
+            .newPath(JSONType.TypeString).key("body").completePath("body");
+
+    public void reset() {
+        status = 0;
+        message.setLength(0);
+        this.message.setLength(0);
+        body.setLength(0);
+    }
+
+    public void setStatusMessage(StatusMessages statusMessage) {
+        this.status = statusMessage.getStatusCode();
+        this.message.append(statusMessage.getStatusMessage());
+    }
+
+    public int getStatus() { return status; }
+
+    public String getMessage() {
+        return message.toString();
+    }
+
+    public String getBody() {
+        return body.toString();
+    }
+
+    public void setBody(String body) {
+        this.body.append(body);
+    }
+
+    public static JSONReader createReader() {
+        return jsonExtractor.reader();
+    }
+
+    public boolean readFromJSON(JSONReader jsonReader, ChannelReader reader) {
+        status = (int)jsonReader.getLong("status".getBytes(), reader);
+        jsonReader.getText("message".getBytes(), reader, message);
+        jsonReader.getText("body".getBytes(), reader, body);
+        return true;
+    }
+
+    public void writeToJSON(AppendableByteWriter writer) {
+        jsonRenderer.render(writer, this);
+    }
+
+    public enum StatusMessages {
+        SUCCESS(200, "Success"),
+        FAILURE(500, "Server Error"),
+        BAD_REQUEST(400, "Bad Request");
+
+        private final int statusCode;
+        private final String statusMessage;
+
+        StatusMessages(int statusCode, String statusMessage) {
+            this.statusCode = statusCode;
+            this.statusMessage = statusMessage;
+        }
+
+        public int getStatusCode() {
+            return statusCode;
+        }
+
+        public String getStatusMessage() {
+            return statusMessage;
+        }
+    }
+}

--- a/src/test/java/com/ociweb/gl/json/JSONServerApp.java
+++ b/src/test/java/com/ociweb/gl/json/JSONServerApp.java
@@ -1,0 +1,43 @@
+package com.ociweb.gl.json;
+import com.ociweb.gl.api.Builder;
+import com.ociweb.gl.api.GreenAppParallel;
+import com.ociweb.gl.api.GreenRuntime;
+
+public class JSONServerApp implements GreenAppParallel {
+    private int InventoryLocationOrgcodRouteId;
+    // Declare connections
+    @Override
+    public void declareConfiguration(Builder builder) {
+        // Setup the server
+        builder.useHTTP1xServer(8088).setHost("127.0.0.1")
+                .useInsecureServer()
+                .setDecryptionUnitsPerTrack(8)
+                .setEncryptionUnitsPerTrack(4)
+                .setConcurrentChannelsPerDecryptUnit(2)
+                .setConcurrentChannelsPerEncryptUnit(2);
+
+        // Enable low-overhead instrumentation
+        builder.enableTelemetry();
+
+        // Create the LocationAtP API
+        InventoryLocationOrgcodRouteId = JSONServerBehavior.defineRoute(builder);
+
+        // This declares that the declareParallelBehavior method gets executed n times.
+        // The scheduler will load balance the behaviors
+        //builder.parallelism(4);
+
+        builder.usePrivateTopicsExclusively();
+    }
+
+    // Declare business logic
+    @Override
+    public void declareBehavior(GreenRuntime runtime) {
+        JSONServerBehavior restListener = new JSONServerBehavior(runtime);
+        runtime.registerListener(restListener).includeRoutes(InventoryLocationOrgcodRouteId); // POST
+    }
+
+    @Override
+    public void declareParallelBehavior(GreenRuntime runtime) {
+        //locationAtpAPI.declareBehavior(runtime);
+    }
+}

--- a/src/test/java/com/ociweb/gl/json/JSONServerBehavior.java
+++ b/src/test/java/com/ociweb/gl/json/JSONServerBehavior.java
@@ -1,0 +1,35 @@
+package com.ociweb.gl.json;
+import com.ociweb.gl.api.*;
+import com.ociweb.pronghorn.network.config.HTTPContentTypeDefaults;
+import com.ociweb.pronghorn.pipe.ChannelWriter;
+
+public class JSONServerBehavior implements RestListener {
+    private final GreenRuntime runtime;
+    private final GreenCommandChannel channel;
+    private final JSONObject response = new JSONObject();
+
+    static int defineRoute(Builder builder) {
+        return builder.defineRoute().path("/atp/location").routeId();
+    }
+
+    JSONServerBehavior(GreenRuntime runtime) {
+        channel = runtime.newCommandChannel(NET_RESPONDER);
+        this.runtime = runtime;
+    }
+
+    @Override
+    public boolean restRequest(HTTPRequestReader request) {
+        System.out.println("Server received request.");
+        channel.publishHTTPResponse(
+                request.getConnectionId(), request.getSequenceCode(),
+                200, false, HTTPContentTypeDefaults.JSON,
+                new Writable() {
+                    @Override
+                    public void write(ChannelWriter writer) {
+                        response.writeToJSON(writer);
+                    }
+                });
+        //runtime.shutdownRuntime();
+        return true;
+    }
+}


### PR DESCRIPTION
New client test fails with...

Client received response.[main] ERROR com.ociweb.pronghorn.stage.scheduling.ScriptedNonThreadScheduler - Unexpected error in JSONClientBehavior #1
StartupListener
 
java.lang.AssertionError: Error malformed data
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:813)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLongB(DataInputBlobReader.java:816)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:809)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:798)
	at com.ociweb.pronghorn.pipe.DataInputBlobReader.readPackedLong(DataInputBlobReader.java:730)
	at com.ociweb.gl.impl.PayloadReader.readPackedLong(PayloadReader.java:216)
	at com.ociweb.pronghorn.util.parse.JSONFieldSchema.getLong(JSONFieldSchema.java:130)
	at com.ociweb.gl.json.JSONObject.readFromJSON(JSONObject.java:59)
	at com.ociweb.gl.json.JSONClientBehavior$2.read(JSONClientBehavior.java:39)
	at com.ociweb.gl.impl.http.server.HTTPPayloadReader.openPayloadData(HTTPPayloadReader.java:142)
	at com.ociweb.gl.json.JSONClientBehavior.responseHTTP(JSONClientBehavior.java:36)
	at com.ociweb.gl.impl.stage.ReactiveListenerStage.consumeNetResponse(ReactiveListenerStage.java:632)
	at com.ociweb.gl.impl.stage.ReactiveListenerStage$2.apply(ReactiveListenerStage.java:306)
	at com.ociweb.gl.impl.stage.ReactiveManagerPipeConsumer.process(ReactiveManagerPipeConsumer.java:28)
	at com.ociweb.gl.impl.stage.ReactiveListenerStage.run(ReactiveListenerStage.java:467)
	at com.ociweb.pronghorn.stage.scheduling.ScriptedNonThreadScheduler.run(ScriptedNonThreadScheduler.java:704)
	at com.ociweb.pronghorn.stage.scheduling.ScriptedNonThreadScheduler.runBlock(ScriptedNonThreadScheduler.java:641)
	at com.ociweb.pronghorn.stage.scheduling.ScriptedNonThreadScheduler.playScript(ScriptedNonThreadScheduler.java:559)
	at com.ociweb.pronghorn.stage.scheduling.ScriptedNonThreadScheduler.run(ScriptedNonThreadScheduler.java:520)
	at com.ociweb.gl.api.GreenRuntime.testUntilShutdownRequested(GreenRuntime.java:132)
	at com.ociweb.gl.json.JSONAppTest.testApp(JSONAppTest.java:10)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)

java.lang.AssertionError: Error malformed data