### PR TITLE
Command-line arg constructed load test config

### DIFF
--- a/src/main/java/com/ociweb/gl/api/ArgumentParser.java
+++ b/src/main/java/com/ociweb/gl/api/ArgumentParser.java
@@ -1,0 +1,90 @@
+package com.ociweb.gl.api;
+
+public class ArgumentParser implements ArgumentProvider {
+    private final String[] args;
+
+    public ArgumentParser(String[] args) {
+        this.args = args;
+    }
+
+    @Override
+    public String[] args() {
+        return args;
+    }
+
+    @Override
+    public String getArgumentValue(String longName, String shortName, String defaultValue) {
+        return getOptArg(longName, shortName, defaultValue);
+    }
+
+    @Override
+    public Character getArgumentValue(String longName, String shortName, Character defaultValue) {
+        String value = getOptArg(longName, shortName, defaultValue!=null?defaultValue.toString():null);
+        return value!=null?value.charAt(0):null;
+    }
+
+    @Override
+    public Byte getArgumentValue(String longName, String shortName, Byte defaultValue) {
+        String value = getOptArg(longName, shortName, defaultValue!=null?defaultValue.toString():null);
+        return value!=null?Byte.parseByte(value):null;
+    }
+
+    @Override
+    public Short getArgumentValue(String longName, String shortName, Short defaultValue) {
+        String value = getOptArg(longName, shortName, defaultValue!=null?defaultValue.toString():null);
+        return value!=null?Short.parseShort(value):null;
+    }
+
+    @Override
+    public Long getArgumentValue(String longName, String shortName, Long defaultValue) {
+        String value = getOptArg(longName, shortName, defaultValue!=null?defaultValue.toString():null);
+        return value!=null?Long.parseLong(value):null;
+    }
+
+    @Override
+    public Integer getArgumentValue(String longName, String shortName, Integer defaultValue) {
+        String value = getOptArg(longName, shortName, defaultValue!=null?defaultValue.toString():null);
+        return value!=null?Integer.parseInt(value):null;
+    }
+
+    @Override
+    public Boolean getArgumentValue(String longName, String shortName, Boolean defaultValue) {
+        String value = getOptArg(longName, shortName, defaultValue!=null?defaultValue.toString():null);
+        return value!=null?Boolean.parseBoolean(value):null;
+    }
+
+    @Override
+    public boolean hasArgument(String longName, String shortName) {
+        return hasArg(longName, shortName);
+    }
+
+    private String getOptArg(String longName, String shortName, String defaultValue) {
+        String prev = null;
+        for (String token : args) {
+            if (longName.equals(prev) || shortName.equals(prev)) {
+                if (token == null || token.trim().length() == 0 || token.startsWith("-")) {
+                    return defaultValue;
+                }
+                return reportChoice(longName, shortName, token.trim());
+            }
+            prev = token;
+        }
+        return reportChoice(longName, shortName, defaultValue);
+    }
+
+
+    private boolean hasArg(String longName, String shortName) {
+        for(String token : args) {
+            if(longName.equals(token) || shortName.equals(token)) {
+                reportChoice(longName, shortName, "");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String reportChoice(final String longName, final String shortName, final String value) {
+        System.out.append(longName).append(" ").append(shortName).append(" ").append(value).append("\n");
+        return value;
+    }
+}

--- a/src/main/java/com/ociweb/gl/api/ArgumentProvider.java
+++ b/src/main/java/com/ociweb/gl/api/ArgumentProvider.java
@@ -1,14 +1,27 @@
 package com.ociweb.gl.api;
 
 /**
- * Separate out the concern for argument fetching for 
+ * Separate out the concern for argument fetching
  *
  * @author David Giovannini
  */
 public interface ArgumentProvider {
     String[] args();
 
+    Boolean getArgumentValue(String longName, String shortName, Boolean defaultValue);
+
+    Character getArgumentValue(String longName, String shortName, Character defaultValue);
+
+    Byte getArgumentValue(String longName, String shortName, Byte defaultValue);
+
+    Short getArgumentValue(String longName, String shortName, Short defaultValue);
+
+    Long getArgumentValue(String longName, String shortName, Long defaultValue);
+
+    Integer getArgumentValue(String longName, String shortName, Integer defaultValue);
+
     String getArgumentValue(String longName, String shortName, String defaultValue);
 
     boolean hasArgument(String longName, String shortName);
 }
+

--- a/src/main/java/com/ociweb/gl/impl/BuilderImpl.java
+++ b/src/main/java/com/ociweb/gl/impl/BuilderImpl.java
@@ -10,22 +10,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.ociweb.gl.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.ociweb.gl.api.Behavior;
-import com.ociweb.gl.api.Builder;
-import com.ociweb.gl.api.GreenCommandChannel;
-import com.ociweb.gl.api.HTTPClientConfig;
-import com.ociweb.gl.api.HTTPRequestReader;
-import com.ociweb.gl.api.HTTPServerConfig;
-import com.ociweb.gl.api.ClientHostPortInstance;
-import com.ociweb.gl.api.ListenerTransducer;
-import com.ociweb.gl.api.MsgCommandChannel;
-import com.ociweb.gl.api.MsgRuntime;
-import com.ociweb.gl.api.NetResponseWriter;
-import com.ociweb.gl.api.TelemetryConfig;
-import com.ociweb.gl.api.TimeTrigger;
 import com.ociweb.gl.api.transducer.HTTPResponseListenerTransducer;
 import com.ociweb.gl.api.transducer.PubSubListenerTransducer;
 import com.ociweb.gl.api.transducer.RestListenerTransducer;
@@ -97,7 +85,7 @@ public class BuilderImpl implements Builder {
 	private Blocker channelBlocker;
 
 	public final GraphManager gm;
-	public final String[] args;
+	public final ArgumentParser args;
 	
 	private int threadLimit = -1;
 	private boolean threadLimitHard = false;
@@ -272,14 +260,6 @@ public class BuilderImpl implements Builder {
 	public final HTTPServerConfig getHTTPServerConfig() {
 		return this.server;
 	}
-    
-    public String getArgumentValue(String longName, String shortName, String defaultValue) {
-    	return MsgRuntime.getOptArg(longName, shortName, args, defaultValue);
-    }
-
-	public boolean hasArgument(String longName, String shortName) {
-		return MsgRuntime.hasArg(longName, shortName, args);
-	}
 
     public int behaviorId(Behavior b) {
     	return BehaviorMask | System.identityHashCode(b);
@@ -401,7 +381,7 @@ public class BuilderImpl implements Builder {
 		
 		this.gm = gm;
 		this.getTempPipeOfStartupSubscriptions().initBuffers();
-		this.args = args;
+		this.args = new ArgumentParser(args);
 		
 		this.pcm.addConfig(new PipeConfig<HTTPRequestSchema>(HTTPRequestSchema.instance, 
 									                   MINIMUM_INCOMMING_REST_REQUESTS_IN_FLIGHT, 
@@ -1233,7 +1213,47 @@ public class BuilderImpl implements Builder {
 
 	@Override
 	public String[] args() {
-		return args;
+		return args.args();
+	}
+
+	@Override
+	public boolean hasArgument(String longName, String shortName) {
+		return args.hasArgument(longName, shortName);
+	}
+
+	@Override
+	public String getArgumentValue(String longName, String shortName, String defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
+	}
+
+	@Override
+	public Boolean getArgumentValue(String longName, String shortName, Boolean defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
+	}
+
+	@Override
+	public Character getArgumentValue(String longName, String shortName, Character defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
+	}
+
+	@Override
+	public Byte getArgumentValue(String longName, String shortName, Byte defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
+	}
+
+	@Override
+	public Short getArgumentValue(String longName, String shortName, Short defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
+	}
+
+	@Override
+	public Long getArgumentValue(String longName, String shortName, Long defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
+	}
+
+	@Override
+	public Integer getArgumentValue(String longName, String shortName, Integer defaultValue) {
+		return args.getArgumentValue(longName, shortName, defaultValue);
 	}
 
 	public void blockChannelDuration(long durationNanos, int pipeId) {

--- a/src/main/java/com/ociweb/gl/test/ParallelClientLoadTester.java
+++ b/src/main/java/com/ociweb/gl/test/ParallelClientLoadTester.java
@@ -56,7 +56,7 @@ public class ParallelClientLoadTester implements GreenAppParallel {
 
 		this(
             new ParallelClientLoadTesterConfig(cyclesPerTrack, port, route, enableTelemetry),
-            post != null ? new ParallelTestPayload(post) : null,
+            post != null ? new ParallelClientLoadTesterPayload(post) : null,
             new DefaultParallelClientLoadTesterOutput());
 	}
 
@@ -70,19 +70,19 @@ public class ParallelClientLoadTester implements GreenAppParallel {
 
 		this(
             new ParallelClientLoadTesterConfig(parallelTracks, cyclesPerTrack, port, route, enableTelemetry),
-            post != null ? new ParallelTestPayload(post) : null,
+            post != null ? new ParallelClientLoadTesterPayload(post) : null,
             new DefaultParallelClientLoadTesterOutput());
 	}
 
 	public ParallelClientLoadTester(
 			ParallelClientLoadTesterConfig config,
-			ParallelTestPayload payload) {
+			ParallelClientLoadTesterPayload payload) {
 		this(config, payload, new DefaultParallelClientLoadTesterOutput());
 	}
 
 	public ParallelClientLoadTester(
 			ParallelClientLoadTesterConfig config,
-			ParallelTestPayload payload,
+			ParallelClientLoadTesterPayload payload,
 			ParallelClientLoadTesterOutput out) {
 
         this.route = config.route;

--- a/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterConfig.java
+++ b/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterConfig.java
@@ -32,9 +32,9 @@ public class ParallelClientLoadTesterConfig {
         responseTimeoutNS = args.getArgumentValue("--timeout", "-to", responseTimeoutNS);
         telemetryPort = args.getArgumentValue("--telemPort", "-tp", telemetryPort);
         telemetryHost = args.getArgumentValue("--telemHost", "-th", telemetryHost);
-        rate = args.getArgumentValue("--rate", "-r", rate);
+        rate = args.getArgumentValue("--rate", "-ra", rate);
         ensureLowLatency = args.getArgumentValue("--lowLatency", "-ll", ensureLowLatency);
-        simultaneousRequestsPerTrack = args.getArgumentValue("--simulRquests", "-s", simultaneousRequestsPerTrack);
+        simultaneousRequestsPerTrack = args.getArgumentValue("--simulRquests", "-sr", simultaneousRequestsPerTrack);
     }
 
     public ParallelClientLoadTesterConfig(

--- a/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterConfig.java
+++ b/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterConfig.java
@@ -1,5 +1,6 @@
 package com.ociweb.gl.test;
 
+import com.ociweb.gl.api.ArgumentProvider;
 import com.ociweb.gl.api.TelemetryConfig;
 
 public class ParallelClientLoadTesterConfig {
@@ -18,6 +19,22 @@ public class ParallelClientLoadTesterConfig {
 	public int simultaneousRequestsPerTrack = 0; // as power of 2. 0 == serial requests opn a track
 
     public ParallelClientLoadTesterConfig() {
+    }
+
+    public ParallelClientLoadTesterConfig(ArgumentProvider args) {
+        host = args.getArgumentValue("--host", "-h", host);
+        port = Integer.parseInt(args.getArgumentValue("--port", "-p", Integer.toString(port)));
+        route = args.getArgumentValue("--route", "-r", route);
+        insecureClient = args.getArgumentValue("--insecure", "-is", insecureClient);
+        parallelTracks = args.getArgumentValue("--tracks", "-t", parallelTracks);
+        cyclesPerTrack = args.getArgumentValue("--cycles", "-c", cyclesPerTrack);
+        durationNanos = args.getArgumentValue("--duration", "-d", durationNanos);
+        responseTimeoutNS = args.getArgumentValue("--timeout", "-to", responseTimeoutNS);
+        telemetryPort = args.getArgumentValue("--telemPort", "-tp", telemetryPort);
+        telemetryHost = args.getArgumentValue("--telemHost", "-th", telemetryHost);
+        rate = args.getArgumentValue("--rate", "-r", rate);
+        ensureLowLatency = args.getArgumentValue("--lowLatency", "-ll", ensureLowLatency);
+        simultaneousRequestsPerTrack = args.getArgumentValue("--simulRquests", "-s", simultaneousRequestsPerTrack);
     }
 
     public ParallelClientLoadTesterConfig(

--- a/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterConfig.java
+++ b/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterConfig.java
@@ -23,7 +23,7 @@ public class ParallelClientLoadTesterConfig {
 
     public ParallelClientLoadTesterConfig(ArgumentProvider args) {
         host = args.getArgumentValue("--host", "-h", host);
-        port = Integer.parseInt(args.getArgumentValue("--port", "-p", Integer.toString(port)));
+        port = args.getArgumentValue("--port", "-p", port);
         route = args.getArgumentValue("--route", "-r", route);
         insecureClient = args.getArgumentValue("--insecure", "-is", insecureClient);
         parallelTracks = args.getArgumentValue("--tracks", "-t", parallelTracks);

--- a/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterPayload.java
+++ b/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterPayload.java
@@ -5,25 +5,25 @@ import com.ociweb.pronghorn.network.config.HTTPContentTypeDefaults;
 
 import java.util.function.Supplier;
 
-public class ParallelTestPayload {
+public class ParallelClientLoadTesterPayload {
     public HTTPContentTypeDefaults contentType = null;
     public Supplier<Writable> post = null;
     public int maxPayloadSize = 512;
 
-    public ParallelTestPayload() {
+    public ParallelClientLoadTesterPayload() {
     }
 
-    public ParallelTestPayload(String payload) {
+    public ParallelClientLoadTesterPayload(String payload) {
         final byte[] bytes = payload.getBytes();
         maxPayloadSize = bytes.length;
         post = ()->writer->writer.write(bytes);
     }
 
-    public ParallelTestPayload(String[] payload) {
+    public ParallelClientLoadTesterPayload(String[] payload) {
         maxPayloadSize = 0;
         for (int i = 0; i < payload.length; i++) {
             maxPayloadSize = Math.max(maxPayloadSize, payload[i].length());
         }
-        post = ()-> new PayloadScript(payload);
+        post = ()-> new ParallelClientLoadTesterPayloadScript(payload);
     }
 }

--- a/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterPayloadScript.java
+++ b/src/main/java/com/ociweb/gl/test/ParallelClientLoadTesterPayloadScript.java
@@ -3,11 +3,11 @@ package com.ociweb.gl.test;
 import com.ociweb.gl.api.Writable;
 import com.ociweb.pronghorn.pipe.ChannelWriter;
 
-public class PayloadScript implements Writable {
+public class ParallelClientLoadTesterPayloadScript implements Writable {
     private final byte[][] scripts;
     private int current = 0;
 
-    public PayloadScript(String[] scripts) {
+    public ParallelClientLoadTesterPayloadScript(String[] scripts) {
         this.scripts = new byte[scripts.length][];
         for (int i = 0; i < scripts.length; i++) {
             this.scripts[i] = scripts[i].getBytes();


### PR DESCRIPTION
Move argument parsing logic out to make available before apps are created. 
Add more types beyond string to arg parsing. 
Rename more load test helpers. 
Add command-line args to load test config.
